### PR TITLE
bugfix: cached routes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The never ending quest to find the cheapest AWS VPC NAT solution for personal pr
 ```
 STACK_NAME=examples-nat \
 PRIVATE_ROUTE_TABLES=rtb-0eee90cf29e333813,rtb-0c1d060b614e74b88 \
+PRIVATE_IP=10.192.10.58 \
 PUBLIC_SUBNETS=subnet-03ad595bb28ce7679,subnet-09f9df1d1d8a2c2c9 \
   ./bin/deploy
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ PUBLIC_SUBNETS=subnet-03ad595bb28ce7679,subnet-09f9df1d1d8a2c2c9 \
 
 ## Testing
 
-### Bandwidth
+I use the AWS System Manager Session Manager to SSH into an instance in a private subnet utilizing the NAT and run:
 
 ```
 yum install python python-pip -y \

--- a/bin/deploy
+++ b/bin/deploy
@@ -12,4 +12,5 @@ aws cloudformation deploy \
   --stack-name $STACK_NAME \
   --parameter-overrides \
     PrivateRouteTables=$PRIVATE_ROUTE_TABLES \
+    PrivateSubnets=$PRIVATE_SUBNETS \
     PublicSubnet=$PUBLIC_SUBNET

--- a/bin/deploy
+++ b/bin/deploy
@@ -12,4 +12,5 @@ aws cloudformation deploy \
   --stack-name $STACK_NAME \
   --parameter-overrides \
     PrivateRouteTables=$PRIVATE_ROUTE_TABLES \
+    PrivateIP=$PRIVATE_IP \
     PublicSubnets=$PUBLIC_SUBNETS

--- a/bin/deploy
+++ b/bin/deploy
@@ -12,5 +12,4 @@ aws cloudformation deploy \
   --stack-name $STACK_NAME \
   --parameter-overrides \
     PrivateRouteTables=$PRIVATE_ROUTE_TABLES \
-    PrivateIP=$PRIVATE_IP \
-    PublicSubnets=$PUBLIC_SUBNETS
+    PublicSubnet=$PUBLIC_SUBNET

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,7 +5,7 @@ env:
     STACK_NAME: examples-nat
     PRIVATE_ROUTE_TABLES: rtb-0eee90cf29e333813,rtb-0c1d060b614e74b88
     PRIVATE_IP: 10.192.10.58
-    PUBLIC_SUBNETS: subnet-03ad595bb28ce7679,subnet-09f9df1d1d8a2c2c9
+    PUBLIC_SUBNETS: subnet-03ad595bb28ce7679
 
 phases:
   install:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,6 +4,7 @@ env:
   variables:
     STACK_NAME: examples-nat
     PRIVATE_ROUTE_TABLES: rtb-0eee90cf29e333813,rtb-0c1d060b614e74b88
+    PRIVATE_SUBNETS: subnet-073717020d44aedd8,subnet-073717020d44aedd8
     PUBLIC_SUBNET: subnet-03ad595bb28ce7679
 
 phases:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,8 +4,7 @@ env:
   variables:
     STACK_NAME: examples-nat
     PRIVATE_ROUTE_TABLES: rtb-0eee90cf29e333813,rtb-0c1d060b614e74b88
-    PRIVATE_IP: 10.192.10.58
-    PUBLIC_SUBNETS: subnet-03ad595bb28ce7679
+    PUBLIC_SUBNET: subnet-03ad595bb28ce7679
 
 phases:
   install:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,6 +4,7 @@ env:
   variables:
     STACK_NAME: examples-nat
     PRIVATE_ROUTE_TABLES: rtb-0eee90cf29e333813,rtb-0c1d060b614e74b88
+    PRIVATE_IP: 10.192.10.58
     PUBLIC_SUBNETS: subnet-03ad595bb28ce7679,subnet-09f9df1d1d8a2c2c9
 
 phases:

--- a/cfn/stack.yml
+++ b/cfn/stack.yml
@@ -110,6 +110,48 @@ Resources:
               --instance-id $INSTANCEID \
               --network-interface-id ${NATStaticNetworkInterface}
 
+            sleep 5
+
+            # Configure the instance to run as a Port Address Translator (PAT) to provide
+            # Internet connectivity to private instances.
+
+            function log { logger -s -t "vpc" -- $1; }
+
+            function die {
+                [ -n "$1" ] && log "$1"
+                log "Configuration of PAT failed!"
+                exit 1
+            }
+
+            # Sanitize PATH
+            export PATH="/usr/sbin:/sbin:/usr/bin:/bin"
+
+            log "Determining the MAC address on eth1..."
+            ETH1_MAC=$(cat /sys/class/net/eth1/address) ||
+                die "Unable to determine MAC address on eth1."
+            log "Found MAC ${!ETH1_MAC} for eth1."
+
+            # This script is intended to run only on a NAT instance for a VPC
+            # Check if the instance is a VPC instance by trying to retrieve vpc id
+            VPC_ID_URI="http://169.254.169.254/latest/meta-data/network/interfaces/macs/${!ETH1_MAC}/vpc-id"
+
+            VPC_ID=$(curl --retry 3 --silent --fail ${!VPC_ID_URI})
+            if [ $? -ne 0 ]; then
+                log "The script is not running on a VPC instance. PAT may masquerade traffic for Internet hosts!"
+            fi
+
+            log "Enabling PAT..."
+            sysctl -q -w net.ipv4.ip_forward=1 net.ipv4.conf.eth1.send_redirects=0 &&
+            (
+                iptables -t nat -C POSTROUTING -o eth1 -j MASQUERADE 2> /dev/null ||
+                iptables -t nat -A POSTROUTING -o eth1 -j MASQUERADE ) ||
+            die
+
+            sysctl net.ipv4.ip_forward net.ipv4.conf.eth1.send_redirects | log
+            iptables -n -t nat -L POSTROUTING | log
+
+            log "Configuration of PAT complete."
+
             IFS=$','
             tables=${PrivateRouteTables}
             for table in $tables; do

--- a/cfn/stack.yml
+++ b/cfn/stack.yml
@@ -83,12 +83,6 @@ Resources:
     Properties:
       PrivateIpAddress: !Ref PrivateIP
       SourceDestCheck: False
-      SubnetId:
-        !Select
-        - 0
-        - !Split
-          - ','
-          - !Ref PublicSubnets
 
   NATInstanceLaunchTemplate:
     Type: AWS::EC2::LaunchTemplate

--- a/cfn/stack.yml
+++ b/cfn/stack.yml
@@ -105,7 +105,7 @@ Resources:
               --instance-id $INSTANCEID \
               --source-dest-check "{\"Value\": false}"
 
-            ENIID=$(aws --region ${Region} ec2 describe-network-interfaces --filter Name=attachment.instance-id,Values=$INSTANCEID --query 'NetworkInterfaces[0].NetworkInterfaceId')
+            ENIID=$(aws --region ${Region} ec2 describe-network-interfaces --filter Name=attachment.instance-id,Values=$INSTANCEID --query 'NetworkInterfaces[0].NetworkInterfaceId' --output text)
 
             aws --region ${Region} ec2 assign-private-ip-addresses \
               --allow-reassignment \

--- a/cfn/stack.yml
+++ b/cfn/stack.yml
@@ -92,7 +92,8 @@ Resources:
           - AMI
         InstanceType: t3.nano
         NetworkInterfaces:
-          - PrivateIpAddress: !Ref PrivateIP
+          - DeviceIndex: '0'
+            PrivateIpAddress: !Ref PrivateIP
             SubnetId:
               !Select
               - 0

--- a/cfn/stack.yml
+++ b/cfn/stack.yml
@@ -78,12 +78,6 @@ Resources:
       Roles:
       - !Ref NATInstanceRole
 
-  NATStaticNetworkInterface:
-    Type: AWS::EC2::NetworkInterface
-    Properties:
-      PrivateIpAddress: !Ref PrivateIP
-      SourceDestCheck: False
-
   NATInstanceLaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
     Properties:
@@ -98,8 +92,14 @@ Resources:
           - AMI
         InstanceType: t3.nano
         NetworkInterfaces:
-          - NetworkInterfaceId: !Ref NATStaticNetworkInterface
-            DeviceIndex: '0'
+          - PrivateIpAddress: !Ref PrivateIP
+            SourceDestCheck: False
+            SubnetId:
+              !Select
+              - 0
+              - !Split
+                - ','
+                - !Ref PublicSubnets
         UserData:
           'Fn::Base64': !Sub
           - |

--- a/cfn/stack.yml
+++ b/cfn/stack.yml
@@ -1,7 +1,10 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 
 Parameters:
   PrivateRouteTables:
+    Type: String
+
+  PrivateSubnets:
     Type: String
 
   PublicSubnet:
@@ -9,15 +12,14 @@ Parameters:
 
 Mappings:
   RegionMap:
-    'ap-southeast-2':
-      AMI: 'ami-00c1445796bc0a29f'
+    "ap-southeast-2":
+      AMI: "ami-00c1445796bc0a29f"
 
 Resources:
   NATInstanceAutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
-      VPCZoneIdentifier:
-        - !Ref PublicSubnet
+      VPCZoneIdentifier: !Split [ ",", !Ref PrivateSubnets ]
       MixedInstancesPolicy:
         InstancesDistribution:
           OnDemandPercentageAboveBaseCapacity: 0
@@ -27,52 +29,72 @@ Resources:
             LaunchTemplateId: !Ref NATInstanceLaunchTemplate
             Version: !GetAtt NATInstanceLaunchTemplate.LatestVersionNumber
           Overrides:
-          - InstanceType: t3a.nano
-          - InstanceType: t3.nano
-      MaxSize: '1'
-      MinSize: '1'
+            - InstanceType: t3a.nano
+            - InstanceType: t3.nano
+      MaxSize: "1"
+      MinSize: "1"
       MetricsCollection:
-      - Granularity: 1Minute
-        Metrics:
-        - GroupInServiceInstances
+        - Granularity: 1Minute
+          Metrics:
+            - GroupInServiceInstances
       Tags:
-      - Key: Name
-        PropagateAtLaunch: true
-        Value: !Join ['', [!Ref 'AWS::AccountId', '-', !Ref 'AWS::Region', '-', !Ref 'AWS::StackName']]
+        - Key: Name
+          PropagateAtLaunch: true
+          Value:
+            !Join [
+              "",
+              [
+                !Ref "AWS::AccountId",
+                "-",
+                !Ref "AWS::Region",
+                "-",
+                !Ref "AWS::StackName",
+              ],
+            ]
 
   NATInstanceRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: '2012-10-17'
+        Version: "2012-10-17"
         Statement:
-        - Effect: Allow
-          Principal:
-            Service:
-            - ec2.amazonaws.com
-          Action: sts:AssumeRole
-      ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
-      Policies:
-      - PolicyName: ec2
-        PolicyDocument:
-          Version: '2012-10-17'
-          Statement:
           - Effect: Allow
-            Action:
-            - 'ec2:ModifyInstanceAttribute'
-            - 'ec2:CreateRoute'
-            - 'ec2:ReplaceRoute'
-            - 'ec2:AttachNetworkInterface'
-            Resource:
-            - '*'
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+      Policies:
+        - PolicyName: ec2
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "ec2:ModifyInstanceAttribute"
+                  - "ec2:CreateRoute"
+                  - "ec2:ReplaceRoute"
+                  - "ec2:AttachNetworkInterface"
+                Resource:
+                  - "*"
 
   NATInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
-      InstanceProfileName: !Join ['', [!Ref 'AWS::AccountId', '-', !Ref 'AWS::Region', '-', !Ref 'AWS::StackName']]
+      InstanceProfileName:
+        !Join [
+          "",
+          [
+            !Ref "AWS::AccountId",
+            "-",
+            !Ref "AWS::Region",
+            "-",
+            !Ref "AWS::StackName",
+          ],
+        ]
       Roles:
-      - !Ref NATInstanceRole
+        - !Ref NATInstanceRole
 
   NATStaticNetworkInterface:
     Type: AWS::EC2::NetworkInterface
@@ -83,66 +105,59 @@ Resources:
   NATInstanceLaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
     Properties:
-      LaunchTemplateName: !Join ['', [!Ref 'AWS::AccountId', '-', !Ref 'AWS::Region', '-', !Ref 'AWS::StackName']]
+      LaunchTemplateName:
+        !Join [
+          "",
+          [
+            !Ref "AWS::AccountId",
+            "-",
+            !Ref "AWS::Region",
+            "-",
+            !Ref "AWS::StackName",
+          ],
+        ]
       LaunchTemplateData:
         IamInstanceProfile:
           Arn: !GetAtt NATInstanceProfile.Arn
         ImageId:
           Fn::FindInMap:
-          - RegionMap
-          - !Ref 'AWS::Region'
-          - AMI
+            - RegionMap
+            - !Ref "AWS::Region"
+            - AMI
         InstanceType: t3.nano
         UserData:
-          'Fn::Base64': !Sub
-          - |
-            #!/bin/bash -ex
-            trap '/opt/aws/bin/cfn-signal -e 1 --region ${Region} --stack ${StackName} --resource NATAutoScalingGroup' ERR
+          "Fn::Base64": !Sub
+            - |
+              #!/bin/bash -ex
+              trap '/opt/aws/bin/cfn-signal -e 1 --region ${Region} --stack ${StackName} --resource NATAutoScalingGroup' ERR
 
-            INSTANCEID=$(curl -s -m 60 http://169.254.169.254/latest/meta-data/instance-id)
+              INSTANCEID=$(curl -s -m 60 http://169.254.169.254/latest/meta-data/instance-id)
 
-            aws --region ${Region} ec2 modify-instance-attribute \
-              --instance-id $INSTANCEID \
-              --source-dest-check "{\"Value\": false}"
-
-            aws --region ${Region} ec2 attach-network-interface \
-              --device-index 1 \
-              --instance-id $INSTANCEID \
-              --network-interface-id ${NATStaticNetworkInterface}
-
-            sleep 5
-
-            iptables -F
-            iptables -t nat -F
-            iptables -t mangle -F
-
-            iptables -t nat -A POSTROUTING -o eth0 -s 10.192.0.0/16 -j MASQUERADE
-            iptables -t nat -A POSTROUTING -o eth1 -s 10.192.0.0/16 -j MASQUERADE
-
-            GW=$(ip route | grep default | awk '{print $3}' | head -n1)
-            ip route del default via $GW dev eth0
-            ip route flush cache
-
-            iptables -L -n -v --line-numbers
-            iptables -t nat -L
-
-            IFS=$','
-            tables=${PrivateRouteTables}
-            for table in $tables; do
-              aws --region ${Region} ec2 replace-route \
-                --route-table-id $table \
-                --destination-cidr-block "0.0.0.0/0" \
-                --network-interface-id ${NATStaticNetworkInterface} || \
-                  aws --region ${Region} ec2 create-route \
-                    --route-table-id $table \
-                    --destination-cidr-block "0.0.0.0/0" \
-                    --network-interface-id ${NATStaticNetworkInterface}
-            done
-            unset IFS
-          - PrivateRouteTables: !Ref PrivateRouteTables
-            Region: !Ref 'AWS::Region'
-            StackName: !Ref 'AWS::StackName'
-            NATStaticNetworkInterface: !Ref NATStaticNetworkInterface
+              aws --region ${Region} ec2 attach-network-interface \
+                --device-index 1 \
+                --instance-id $INSTANCEID \
+                --network-interface-id ${NATStaticNetworkInterface}
 
 
+              sleep 5
 
+              iptables -L -n -v --line-numbers
+              iptables -t nat -L
+
+              IFS=$','
+              tables=${PrivateRouteTables}
+              for table in $tables; do
+                aws --region ${Region} ec2 replace-route \
+                  --route-table-id $table \
+                  --destination-cidr-block "0.0.0.0/0" \
+                  --network-interface-id ${NATStaticNetworkInterface} || \
+                    aws --region ${Region} ec2 create-route \
+                      --route-table-id $table \
+                      --destination-cidr-block "0.0.0.0/0" \
+                      --network-interface-id ${NATStaticNetworkInterface}
+              done
+              unset IFS
+            - PrivateRouteTables: !Ref PrivateRouteTables
+              Region: !Ref "AWS::Region"
+              StackName: !Ref "AWS::StackName"
+              NATStaticNetworkInterface: !Ref NATStaticNetworkInterface

--- a/cfn/stack.yml
+++ b/cfn/stack.yml
@@ -112,45 +112,9 @@ Resources:
 
             sleep 5
 
-            # Configure the instance to run as a Port Address Translator (PAT) to provide
-            # Internet connectivity to private instances.
-
-            function log { logger -s -t "vpc" -- $1; }
-
-            function die {
-                [ -n "$1" ] && log "$1"
-                log "Configuration of PAT failed!"
-                exit 1
-            }
-
-            # Sanitize PATH
-            export PATH="/usr/sbin:/sbin:/usr/bin:/bin"
-
-            log "Determining the MAC address on eth1..."
-            ETH1_MAC=$(cat /sys/class/net/eth1/address) ||
-                die "Unable to determine MAC address on eth1."
-            log "Found MAC ${!ETH1_MAC} for eth1."
-
-            # This script is intended to run only on a NAT instance for a VPC
-            # Check if the instance is a VPC instance by trying to retrieve vpc id
-            VPC_ID_URI="http://169.254.169.254/latest/meta-data/network/interfaces/macs/${!ETH1_MAC}/vpc-id"
-
-            VPC_ID=$(curl --retry 3 --silent --fail ${!VPC_ID_URI})
-            if [ $? -ne 0 ]; then
-                log "The script is not running on a VPC instance. PAT may masquerade traffic for Internet hosts!"
-            fi
-
-            log "Enabling PAT..."
-            sysctl -q -w net.ipv4.ip_forward=1 net.ipv4.conf.eth1.send_redirects=0 &&
-            (
-                iptables -t nat -C POSTROUTING -o eth1 -j MASQUERADE 2> /dev/null ||
-                iptables -t nat -A POSTROUTING -o eth1 -j MASQUERADE ) ||
-            die
-
-            sysctl net.ipv4.ip_forward net.ipv4.conf.eth1.send_redirects | log
-            iptables -n -t nat -L POSTROUTING | log
-
-            log "Configuration of PAT complete."
+            iptables -A FORWARD -i eth1 -o eth0 -j ACCEPT
+            iptables -A FORWARD -i eth0 -o eth1 -m state --state ESTABLISHED,RELATED \
+                     -j ACCEPT
 
             IFS=$','
             tables=${PrivateRouteTables}
@@ -169,3 +133,6 @@ Resources:
             Region: !Ref 'AWS::Region'
             StackName: !Ref 'AWS::StackName'
             NATStaticNetworkInterface: !Ref NATStaticNetworkInterface
+
+
+

--- a/cfn/stack.yml
+++ b/cfn/stack.yml
@@ -68,7 +68,8 @@ Resources:
             - 'ec2:ModifyInstanceAttribute'
             - 'ec2:CreateRoute'
             - 'ec2:ReplaceRoute'
-            - 'ec2:AttachNetworkInterface'
+            - 'ec2:DescribeNetworkInterfaces'
+            - 'ec2:AssignPrivateIpAddresses'
             Resource:
             - '*'
 
@@ -78,18 +79,6 @@ Resources:
       InstanceProfileName: !Join ['', [!Ref 'AWS::AccountId', '-', !Ref 'AWS::Region', '-', !Ref 'AWS::StackName']]
       Roles:
       - !Ref NATInstanceRole
-
-  NATStaticNetworkInterface:
-    Type: AWS::EC2::NetworkInterface
-    Properties:
-      PrivateIpAddress: !Ref PrivateIP
-      SourceDestCheck: False
-      SubnetId:
-        !Select
-        - 0
-        - !Split
-          - ','
-          - !Ref PublicSubnets
 
   NATInstanceLaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
@@ -116,10 +105,12 @@ Resources:
               --instance-id $INSTANCEID \
               --source-dest-check "{\"Value\": false}"
 
-            aws attach-network-interface \
-              --device-index 1 \
-              --instance-id $INSTANCEID \
-              --network-interface-id ${NATStaticNetworkInterface}
+            ENIID=$(aws --region ${Region} ec2 describe-network-interfaces --filter Name=attachment.instance-id,Values=$INSTANCEID --query 'NetworkInterfaces[0].NetworkInterfaceId')
+
+            aws --region ${Region} ec2 assign-private-ip-addresses \
+              --allow-reassignment \
+              --private-ip-addresses ${PrivateIP} \
+              --network-interface-id $ENIID \
 
             IFS=$','
             tables=${PrivateRouteTables}
@@ -137,4 +128,4 @@ Resources:
           - PrivateRouteTables: !Ref PrivateRouteTables
             Region: !Ref 'AWS::Region'
             StackName: !Ref 'AWS::StackName'
-            NATStaticNetworkInterface: !Ref NATStaticNetworkInterface
+            PrivateIP: !Ref PrivateIP

--- a/cfn/stack.yml
+++ b/cfn/stack.yml
@@ -68,6 +68,7 @@ Resources:
             - 'ec2:ModifyInstanceAttribute'
             - 'ec2:CreateRoute'
             - 'ec2:ReplaceRoute'
+            - 'ec2:AttachNetworkInterface'
             Resource:
             - '*'
 
@@ -77,6 +78,18 @@ Resources:
       InstanceProfileName: !Join ['', [!Ref 'AWS::AccountId', '-', !Ref 'AWS::Region', '-', !Ref 'AWS::StackName']]
       Roles:
       - !Ref NATInstanceRole
+
+  NATStaticNetworkInterface:
+    Type: AWS::EC2::NetworkInterface
+    Properties:
+      PrivateIpAddress: !Ref PrivateIP
+      SourceDestCheck: False
+      SubnetId:
+        !Select
+        - 0
+        - !Split
+          - ','
+          - !Ref PublicSubnets
 
   NATInstanceLaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
@@ -91,15 +104,6 @@ Resources:
           - !Ref 'AWS::Region'
           - AMI
         InstanceType: t3.nano
-        NetworkInterfaces:
-          - DeviceIndex: '0'
-            PrivateIpAddress: !Ref PrivateIP
-            SubnetId:
-              !Select
-              - 0
-              - !Split
-                - ','
-                - !Ref PublicSubnets
         UserData:
           'Fn::Base64': !Sub
           - |
@@ -111,6 +115,11 @@ Resources:
             aws --region ${Region} ec2 modify-instance-attribute \
               --instance-id $INSTANCEID \
               --source-dest-check "{\"Value\": false}"
+
+            aws attach-network-interface \
+              --device-index 1 \
+              --instance-id $INSTANCEID \
+              --network-interface-id ${NATStaticNetworkInterface}
 
             IFS=$','
             tables=${PrivateRouteTables}
@@ -128,3 +137,4 @@ Resources:
           - PrivateRouteTables: !Ref PrivateRouteTables
             Region: !Ref 'AWS::Region'
             StackName: !Ref 'AWS::StackName'
+            NATStaticNetworkInterface: !Ref NATStaticNetworkInterface

--- a/cfn/stack.yml
+++ b/cfn/stack.yml
@@ -93,7 +93,6 @@ Resources:
         InstanceType: t3.nano
         NetworkInterfaces:
           - PrivateIpAddress: !Ref PrivateIP
-            SourceDestCheck: False
             SubnetId:
               !Select
               - 0
@@ -107,6 +106,10 @@ Resources:
             trap '/opt/aws/bin/cfn-signal -e 1 --region ${Region} --stack ${StackName} --resource NATAutoScalingGroup' ERR
 
             INSTANCEID=$(curl -s -m 60 http://169.254.169.254/latest/meta-data/instance-id)
+
+            aws --region ${Region} ec2 modify-instance-attribute \
+              --instance-id $INSTANCEID \
+              --source-dest-check "{\"Value\": false}"
 
             IFS=$','
             tables=${PrivateRouteTables}

--- a/cfn/stack.yml
+++ b/cfn/stack.yml
@@ -112,8 +112,17 @@ Resources:
 
             sleep 5
 
-            iptables -t nat -A POSTROUTING --out-interface eth0 -j MASQUERADE
-            iptables -A FORWARD --in-interface eth1 -j ACCEPT
+            iptables -F
+            iptables -t nat -F
+            iptables -t mangle -F
+
+            iptables -t nat -A POSTROUTING -o eth0 -s 10.192.0.0/16 -j MASQUERADE
+            iptables -t nat -A POSTROUTING -o eth1 -s 10.192.0.0/16 -j MASQUERADE
+
+            GW=$(ip route | grep default | awk '{print $3}' | head -n1)
+            ip route del default via $GW dev eth0
+            ip route flush cache
+
             iptables -L -n -v --line-numbers
             iptables -t nat -L
 

--- a/cfn/stack.yml
+++ b/cfn/stack.yml
@@ -4,10 +4,7 @@ Parameters:
   PrivateRouteTables:
     Type: String
 
-  PrivateIP:
-    Type: String
-
-  PublicSubnets:
+  PublicSubnet:
     Type: String
 
 Mappings:
@@ -20,9 +17,7 @@ Resources:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
       VPCZoneIdentifier:
-        !Split
-        - ','
-        - !Ref PublicSubnets
+        - !Ref PublicSubnet
       MixedInstancesPolicy:
         InstancesDistribution:
           OnDemandPercentageAboveBaseCapacity: 0
@@ -68,8 +63,7 @@ Resources:
             - 'ec2:ModifyInstanceAttribute'
             - 'ec2:CreateRoute'
             - 'ec2:ReplaceRoute'
-            - 'ec2:DescribeNetworkInterfaces'
-            - 'ec2:AssignPrivateIpAddresses'
+            - 'ec2:AttachNetworkInterface'
             Resource:
             - '*'
 
@@ -79,6 +73,12 @@ Resources:
       InstanceProfileName: !Join ['', [!Ref 'AWS::AccountId', '-', !Ref 'AWS::Region', '-', !Ref 'AWS::StackName']]
       Roles:
       - !Ref NATInstanceRole
+
+  NATStaticNetworkInterface:
+    Type: AWS::EC2::NetworkInterface
+    Properties:
+      SubnetId: !Ref PublicSubnet
+      SourceDestCheck: False
 
   NATInstanceLaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
@@ -105,12 +105,10 @@ Resources:
               --instance-id $INSTANCEID \
               --source-dest-check "{\"Value\": false}"
 
-            ENIID=$(aws --region ${Region} ec2 describe-network-interfaces --filter Name=attachment.instance-id,Values=$INSTANCEID --query 'NetworkInterfaces[0].NetworkInterfaceId' --output text)
-
-            aws --region ${Region} ec2 assign-private-ip-addresses \
-              --allow-reassignment \
-              --private-ip-addresses ${PrivateIP} \
-              --network-interface-id $ENIID
+            aws --region ${Region} ec2 attach-network-interface \
+              --device-index 1 \
+              --instance-id $INSTANCEID \
+              --network-interface-id ${NATStaticNetworkInterface}
 
             IFS=$','
             tables=${PrivateRouteTables}
@@ -118,14 +116,14 @@ Resources:
               aws --region ${Region} ec2 replace-route \
                 --route-table-id $table \
                 --destination-cidr-block "0.0.0.0/0" \
-                --instance-id $INSTANCEID || \
+                --network-interface-id ${NATStaticNetworkInterface} || \
                   aws --region ${Region} ec2 create-route \
                   --route-table-id $table \
                   --destination-cidr-block "0.0.0.0/0" \
-                  --instance-id $INSTANCEID
+                  --network-interface-id ${NATStaticNetworkInterface}
             done
             unset IFS
           - PrivateRouteTables: !Ref PrivateRouteTables
             Region: !Ref 'AWS::Region'
             StackName: !Ref 'AWS::StackName'
-            PrivateIP: !Ref PrivateIP
+            NATStaticNetworkInterface: !Ref NATStaticNetworkInterface

--- a/cfn/stack.yml
+++ b/cfn/stack.yml
@@ -4,8 +4,11 @@ Parameters:
   PrivateRouteTables:
     Type: String
 
+  PrivateIP:
+    Type: String
+
   PublicSubnets:
-    Type: String 
+    Type: String
 
 Mappings:
   RegionMap:
@@ -15,20 +18,20 @@ Mappings:
 Resources:
   NATInstanceAutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
-    Properties: 
-      VPCZoneIdentifier: 
-        !Split 
+    Properties:
+      VPCZoneIdentifier:
+        !Split
         - ','
         - !Ref PublicSubnets
       MixedInstancesPolicy:
-        InstancesDistribution: 
+        InstancesDistribution:
           OnDemandPercentageAboveBaseCapacity: 0
           SpotAllocationStrategy: lowest-price
-        LaunchTemplate: 
+        LaunchTemplate:
           LaunchTemplateSpecification:
             LaunchTemplateId: !Ref NATInstanceLaunchTemplate
             Version: !GetAtt NATInstanceLaunchTemplate.LatestVersionNumber
-          Overrides: 
+          Overrides:
           - InstanceType: t3a.nano
           - InstanceType: t3.nano
       MaxSize: '1'
@@ -70,17 +73,29 @@ Resources:
 
   NATInstanceProfile:
     Type: AWS::IAM::InstanceProfile
-    Properties: 
+    Properties:
       InstanceProfileName: !Join ['', [!Ref 'AWS::AccountId', '-', !Ref 'AWS::Region', '-', !Ref 'AWS::StackName']]
-      Roles: 
+      Roles:
       - !Ref NATInstanceRole
+
+  NATStaticNetworkInterface:
+    Type: AWS::EC2::NetworkInterface
+    Properties:
+      PrivateIpAddress: !Ref PrivateIP
+      SourceDestCheck: False
+      SubnetId:
+        !Select
+        - 0
+        - !Split
+          - ','
+          - !Ref PublicSubnets
 
   NATInstanceLaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
     Properties:
       LaunchTemplateName: !Join ['', [!Ref 'AWS::AccountId', '-', !Ref 'AWS::Region', '-', !Ref 'AWS::StackName']]
       LaunchTemplateData:
-        IamInstanceProfile: 
+        IamInstanceProfile:
           Arn: !GetAtt NATInstanceProfile.Arn
         ImageId:
           Fn::FindInMap:
@@ -88,6 +103,9 @@ Resources:
           - !Ref 'AWS::Region'
           - AMI
         InstanceType: t3.nano
+        NetworkInterfaces:
+          - NetworkInterfaceId: !Ref NATStaticNetworkInterface
+            DeviceIndex: '0'
         UserData:
           'Fn::Base64': !Sub
           - |
@@ -95,10 +113,6 @@ Resources:
             trap '/opt/aws/bin/cfn-signal -e 1 --region ${Region} --stack ${StackName} --resource NATAutoScalingGroup' ERR
 
             INSTANCEID=$(curl -s -m 60 http://169.254.169.254/latest/meta-data/instance-id)
-
-            aws --region ${Region} ec2 modify-instance-attribute \
-              --instance-id $INSTANCEID \
-              --source-dest-check "{\"Value\": false}"
 
             IFS=$','
             tables=${PrivateRouteTables}
@@ -116,4 +130,3 @@ Resources:
           - PrivateRouteTables: !Ref PrivateRouteTables
             Region: !Ref 'AWS::Region'
             StackName: !Ref 'AWS::StackName'
-      

--- a/cfn/stack.yml
+++ b/cfn/stack.yml
@@ -112,10 +112,10 @@ Resources:
 
             sleep 5
 
-            iptables -A FORWARD -i eth1 -o eth0 -j ACCEPT
-            iptables -A FORWARD -i eth0 -o eth1 -m state --state ESTABLISHED,RELATED -j ACCEPT
-            iptables -t nat -C POSTROUTING -o eth1 -j MASQUERADE 2> /dev/null || iptables -t nat -A POSTROUTING -o eth1 -j MASQUERADE
+            iptables -t nat -A POSTROUTING --out-interface eth0 -j MASQUERADE
+            iptables -A FORWARD --in-interface eth1 -j ACCEPT
             iptables -L -n -v --line-numbers
+            iptables -t nat -L
 
             IFS=$','
             tables=${PrivateRouteTables}

--- a/cfn/stack.yml
+++ b/cfn/stack.yml
@@ -110,7 +110,7 @@ Resources:
             aws --region ${Region} ec2 assign-private-ip-addresses \
               --allow-reassignment \
               --private-ip-addresses ${PrivateIP} \
-              --network-interface-id $ENIID \
+              --network-interface-id $ENIID
 
             IFS=$','
             tables=${PrivateRouteTables}

--- a/cfn/stack.yml
+++ b/cfn/stack.yml
@@ -113,8 +113,9 @@ Resources:
             sleep 5
 
             iptables -A FORWARD -i eth1 -o eth0 -j ACCEPT
-            iptables -A FORWARD -i eth0 -o eth1 -m state --state ESTABLISHED,RELATED \
-                     -j ACCEPT
+            iptables -A FORWARD -i eth0 -o eth1 -m state --state ESTABLISHED,RELATED -j ACCEPT
+            iptables -t nat -C POSTROUTING -o eth1 -j MASQUERADE 2> /dev/null || iptables -t nat -A POSTROUTING -o eth1 -j MASQUERADE
+            iptables -L -n -v --line-numbers
 
             IFS=$','
             tables=${PrivateRouteTables}
@@ -124,9 +125,9 @@ Resources:
                 --destination-cidr-block "0.0.0.0/0" \
                 --network-interface-id ${NATStaticNetworkInterface} || \
                   aws --region ${Region} ec2 create-route \
-                  --route-table-id $table \
-                  --destination-cidr-block "0.0.0.0/0" \
-                  --network-interface-id ${NATStaticNetworkInterface}
+                    --route-table-id $table \
+                    --destination-cidr-block "0.0.0.0/0" \
+                    --network-interface-id ${NATStaticNetworkInterface}
             done
             unset IFS
           - PrivateRouteTables: !Ref PrivateRouteTables


### PR DESCRIPTION
Wireguard does:

```
PostUp   = iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT; iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
PostDown = iptables -D FORWARD -i %i -j ACCEPT; iptables -D FORWARD -o %i -j ACCEPT; iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE
```

```
iptables -t nat -A POSTROUTING --out-interface eth0 -j MASQUERADE
iptables -A FORWARD --in-interface eth1 -j ACCEPT
```

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html

```
yum install ec2-net-utils
```