### PR TITLE
bugfix: existing instances lose egress when NAT instance changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The never ending quest to find the cheapest AWS VPC NAT solution for personal pr
 ```
 STACK_NAME=examples-nat \
 PRIVATE_ROUTE_TABLES=rtb-0eee90cf29e333813,rtb-0c1d060b614e74b88 \
-PUBLIC_SUBNETS=subnet-03ad595bb28ce7679,subnet-09f9df1d1d8a2c2c9 \
+PUBLIC_SUBNET=subnet-03ad595bb28ce7679 \
   ./bin/deploy
 ```
 
@@ -48,3 +48,61 @@ Upload: 2274.26 Mbit/s
 [3]: https://codebuild.us-east-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiWVdkQTF5ekRUSm1FNjgxT0RsL0ZBanFER1dSRG1kQWI0VUNLS2NlS0EwZ0pjdmN5a1RVSGI5K2p5Ty9vZFVZZ2gxck1GOWM4bHJ3WC9VVzJhZDVieE9vPSIsIml2UGFyYW1ldGVyU3BlYyI6IlhoM1dkMGw4M3VFNXlZWU4iLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master
 [4]: https://console.aws.amazon.com/codesuite/codebuild/projects/examples-cheapest-nat/history?region=us-east-1
 
+## Notes
+
+[VPC NAT Instance Documentation](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_NAT_Instance.html)
+
+```
+cat /etc/sysctl.d/10-nat-settings.conf
+#
+# NAT AMI settings
+#
+
+net.ipv4.ip_forward = 1
+net.ipv4.conf.eth0.send_redirects = 0
+```
+
+```
+at /usr/sbin/configure-pat.sh
+#!/bin/bash
+# Configure the instance to run as a Port Address Translator (PAT) to provide
+# Internet connectivity to private instances.
+
+function log { logger -s -t "vpc" -- $1; }
+
+function die {
+    [ -n "$1" ] && log "$1"
+    log "Configuration of PAT failed!"
+    exit 1
+}
+
+# Sanitize PATH
+export PATH="/usr/sbin:/sbin:/usr/bin:/bin"
+
+log "Determining the MAC address on eth0..."
+ETH0_MAC=$(cat /sys/class/net/eth0/address) ||
+    die "Unable to determine MAC address on eth0."
+log "Found MAC ${ETH0_MAC} for eth0."
+
+# This script is intended to run only on a NAT instance for a VPC
+# Check if the instance is a VPC instance by trying to retrieve vpc id
+VPC_ID_URI="http://169.254.169.254/latest/meta-data/network/interfaces/macs/${ETH0_MAC}/vpc-id"
+
+VPC_ID=$(curl --retry 3 --silent --fail ${VPC_ID_URI})
+if [ $? -ne 0 ]; then
+   log "The script is not running on a VPC instance. PAT may masquerade traffic for Internet hosts!"
+fi
+
+log "Enabling PAT..."
+sysctl -q -w net.ipv4.ip_forward=1 net.ipv4.conf.eth0.send_redirects=0 &&
+(
+    iptables -t nat -C POSTROUTING -o eth0 -j MASQUERADE 2> /dev/null ||
+    iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE ) ||
+die
+
+sysctl net.ipv4.ip_forward net.ipv4.conf.eth0.send_redirects | log
+iptables -n -t nat -L POSTROUTING | log
+
+log "Configuration of PAT complete."
+exit 0
+```

--- a/bin/deploy
+++ b/bin/deploy
@@ -12,4 +12,4 @@ aws cloudformation deploy \
   --stack-name $STACK_NAME \
   --parameter-overrides \
     PrivateRouteTables=$PRIVATE_ROUTE_TABLES \
-    PublicSubnets=$PUBLIC_SUBNETS
+    PublicSubnet=$PUBLIC_SUBNET

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,7 +4,7 @@ env:
   variables:
     STACK_NAME: examples-nat
     PRIVATE_ROUTE_TABLES: rtb-0eee90cf29e333813,rtb-0c1d060b614e74b88
-    PUBLIC_SUBNETS: subnet-03ad595bb28ce7679,subnet-09f9df1d1d8a2c2c9
+    PUBLIC_SUBNET: subnet-03ad595bb28ce7679
 
 phases:
   install:

--- a/cfn/stack.yml
+++ b/cfn/stack.yml
@@ -4,7 +4,7 @@ Parameters:
   PrivateRouteTables:
     Type: String
 
-  PublicSubnets:
+  PublicSubnet:
     Type: String
 
 Mappings:
@@ -17,9 +17,7 @@ Resources:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
       VPCZoneIdentifier:
-        !Split
-        - ','
-        - !Ref PublicSubnets
+      - !Ref PublicSubnet
       MixedInstancesPolicy:
         InstancesDistribution:
           OnDemandPercentageAboveBaseCapacity: 0
@@ -65,8 +63,24 @@ Resources:
             - 'ec2:ModifyInstanceAttribute'
             - 'ec2:CreateRoute'
             - 'ec2:ReplaceRoute'
+            - "ec2:AttachNetworkInterface"
             Resource:
             - '*'
+
+  NATStaticNetworkInterface:
+    Type: AWS::EC2::NetworkInterface
+    Properties:
+      SubnetId: !Ref PublicSubnet
+      SourceDestCheck: False
+
+  NATEIP:
+    Type: AWS::EC2::EIP
+
+  NATEIPAssociation:
+    Type: AWS::EC2::EIPAssociation
+    Properties:
+      NetworkInterfaceId: !Ref NATStaticNetworkInterface
+      AllocationId: !GetAtt NATEIP.AllocationId
 
   NATInstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -100,19 +114,35 @@ Resources:
               --instance-id $INSTANCEID \
               --source-dest-check "{\"Value\": false}"
 
+            aws --region ${Region} ec2 attach-network-interface \
+                --device-index 1 \
+                --instance-id $INSTANCEID \
+                --network-interface-id ${NATStaticNetworkInterface}
+
+            while ! ip link show dev eth1; do
+              sleep 1
+            done
+
+            sysctl -q -w net.ipv4.ip_forward=1
+            sysctl -q -w net.ipv4.conf.eth1.send_redirects=0
+            iptables -t nat -A POSTROUTING -o eth1 -j MASQUERADE
+
+            ip route del default dev eth0
+
             IFS=$','
             tables=${PrivateRouteTables}
             for table in $tables; do
               aws --region ${Region} ec2 replace-route \
                 --route-table-id $table \
                 --destination-cidr-block "0.0.0.0/0" \
-                --instance-id $INSTANCEID || \
+                --network-interface-id ${NATStaticNetworkInterface} || \
                   aws --region ${Region} ec2 create-route \
-                  --route-table-id $table \
-                  --destination-cidr-block "0.0.0.0/0" \
-                  --instance-id $INSTANCEID
+                    --route-table-id $table \
+                    --destination-cidr-block "0.0.0.0/0" \
+                    --network-interface-id ${NATStaticNetworkInterface}
             done
             unset IFS
           - PrivateRouteTables: !Ref PrivateRouteTables
-            Region: !Ref 'AWS::Region'
-            StackName: !Ref 'AWS::StackName'
+            Region: !Ref "AWS::Region"
+            StackName: !Ref "AWS::StackName"
+            NATStaticNetworkInterface: !Ref NATStaticNetworkInterface


### PR DESCRIPTION
- Use static eni route to ensure route becomes valid again.
- NAT isntance limited to one az because eni must belong in one.